### PR TITLE
Fix Dockerfile for macOS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18
+FROM --platform=linux/amd64 node:18
 
 
 # We don't need the standalone Chromium


### PR DESCRIPTION
When I run the current `docker build .` command, I receive the error `Unable to locate package google-chrome-stable`. The problem seems to be that there's no `google-chrome-stable` package for 'arm' platforms (macOS). I managed to fix this by pulling the `amd64` image of Node instead. This PR pins the Docker build image to `amd64`.